### PR TITLE
fix fmt flags to be osx compatible

### DIFF
--- a/runManifestDemo.sh
+++ b/runManifestDemo.sh
@@ -209,7 +209,7 @@ if [[ -e $DEMO_DIR ]]; then
 		The demo archive destination path ${DEMO_DIR} already exists; attempting to
 		remove it.
 		EOF
-  } | fmt -uw 78
+  } | fmt -w 78
   run rm -rf "$DEMO_DIR"
 fi
 


### PR DESCRIPTION
The -u flag is merely window dressing and can be removed.

    fmt: illegal option -- u
    usage:   fmt [-cmps] [-d chars] [-l num] [-t num]
                 [-w width | -width | goal [maximum]] [file ...]
    Options: -c     center each line instead of formatting
             -d <chars> double-space after <chars> at line end
             -l <n> turn each <n> spaces at start of line into a tab
             -m     try to make sure mail header lines stay separate
             -n     format lines beginning with a dot
             -p     allow indented paragraphs
             -s     coalesce whitespace inside lines
             -t <n> have tabs every <n> columns
             -w <n> set maximum width to <n>
             goal   set target width to goal