### PR TITLE
fix message to display multiple refs

### DIFF
--- a/lsstswBuild.sh
+++ b/lsstswBuild.sh
@@ -154,7 +154,7 @@ if [[ ! -x ${LSSTSW}/bin/rebuild ]]; then
   fail "Failed to find 'rebuild'."
 fi
 
-print_info "Rebuild is commencing....stand by; using $REF_LIST"
+print_info "Rebuild is commencing....stand by; using ${REF_LIST[*]}"
 
 ARGS=()
 


### PR DESCRIPTION
If multiple git refs were specified, only the first would be listed in
the "Rebuild is commencing..." message.