### PR TITLE
Always use separate conda environments rather than lsst-scipipe.

### DIFF
--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -123,7 +123,7 @@ esac
     OPTS+=('-b')
   fi
 
-  ./bin/deploy "${OPTS[@]}"
+  ./bin/deploy -r "$LSST_SPLENV_REF" "${OPTS[@]}"
 )
 
 "${SCRIPT_DIR}/lsstswBuild.sh" "${ARGS[@]}"

--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -125,7 +125,8 @@ esac
 
   ./bin/deploy -r "$LSST_SPLENV_REF" "${OPTS[@]}"
 )
-
+# environment name is used in setup.sh called from lsstswBuild.sh
+export LSST_CONDA_ENV_NAME="lsst-scipipe-${LSST_SPLENV_REF}"
 "${SCRIPT_DIR}/lsstswBuild.sh" "${ARGS[@]}"
 
 # vim: tabstop=2 shiftwidth=2 expandtab


### PR DESCRIPTION
Sharing the lsst-scipipe conda environment in Jenkins leads to problems if it has been upgraded, as downgrading to a different set of packages, even when consistent, often fails.  Use the capabilities of `deploy` and `setup.sh` to use distinct conda environments.