### PR TITLE
Limit number of processes used to max 8.

### DIFF
--- a/run_validate_drp.sh
+++ b/run_validate_drp.sh
@@ -72,7 +72,7 @@ target_cores() {
 
   local target_cores
   target_cores=$(awk "BEGIN{ print int($sys_mem / $mem_per_core) }")
-  [[ $target_cores > $sys_cores ]] && target_cores=$sys_cores
+  [[ $target_cores -gt $sys_cores ]] && target_cores=$sys_cores
 
   echo "$target_cores"
 }
@@ -123,6 +123,9 @@ esac
 # need to set NUMPROC to the number of cores to utilize + 1
 MEM_PER_CORE=2.0
 export NUMPROC=$(($(target_cores $MEM_PER_CORE) + 1))
+# Jenkins sees all the hardware cores rather than the number configured
+# for a worker, so limit to a max of 8
+[[ $NUMPROC -gt 8 ]] && NUMPROC=8
 
 set +e
 "$RUN" -- --noplot


### PR DESCRIPTION
Jenkins was running slowly because the number of visible cores is all the hardware cores.