### PR TITLE
Limit CPUs used by rebuild/eupspkg.

### DIFF
--- a/lsstswBuild.sh
+++ b/lsstswBuild.sh
@@ -134,6 +134,7 @@ no_color
 
 end_section # configuration
 
+export EUPSPKG_NJOBS=${K8S_DIND_LIMITS_CPU:-8}
 
 #
 # display environment variables


### PR DESCRIPTION
The K8s environment variable is not actually visible to this script (yet), but we use it in anticipation of making it available.  Set a max of 8 cores if it isn't.