### PR TITLE
Introducing rubin-env

### DIFF
--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -106,18 +106,26 @@ esac
     OPTS+=('-b')
   fi
 
-  # The LSST_SPLENV_REF can refer to a rubin-env version
-  #  or to an old scipipe_conda_env SHA1
-  if [[ $LSST_SPLENV_REF =~ [0-9]+\.[0-9]+\.[0-9A-Za-z-]+ ]]; then
-    ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
+  if [[ -z "$RUBINENV_ORG_FORK" ]]; then
+    # The LSST_SPLENV_REF can refer to a rubin-env version
+    #  or to an old scipipe_conda_env SHA1
+    if [[ $LSST_SPLENV_REF =~ [0-9]+\.[0-9]+\.[0-9A-Za-z-]+ ]]; then
+      ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
+    else
+      # this may be required in case we want to do a patch on a major release
+      #  pre instroduction of rubin-env
+      ./bin/deploy -r "$LSST_SPLENV_REF" "${OPTS[@]}"
+    fi
+    LSST_CONDA_ENV_NAME="lsst-scipipe-${LSST_SPLENV_REF}"
   else
-    # this may be required in case we want to do a patch on a major release
-    #  pre instroduction of rubin-env
-    ./bin/deploy -r "$LSST_SPLENV_REF" "${OPTS[@]}"
+    # build and deploy a rubinenv environment from fork/branch
+    ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
+    ./bin/set_prereleased_env "$RUBINENV_ORG_FORK" "$RUBINENV_BRANCH"
+    LSST_CONDA_ENV_NAME=$(cat rubinenv-feedstock/env.name)
   fi
 )
 # environment name is used in envconfig (previously setup.sh) called from lsstswBuild.sh
-export LSST_CONDA_ENV_NAME="lsst-scipipe-${LSST_SPLENV_REF}"
+export LSST_CONDA_ENV_NAME
 "${SCRIPT_DIR}/lsstswBuild.sh" "${ARGS[@]}"
 
 # vim: tabstop=2 shiftwidth=2 expandtab

--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -106,7 +106,8 @@ esac
     OPTS+=('-b')
   fi
 
-  ./bin/deploy -r "$LSST_SPLENV_REF" "${OPTS[@]}"
+  # updated from -r to -v whit the introduction of rubin-env
+  ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
 )
 # environment name is used in setup.sh called from lsstswBuild.sh
 export LSST_CONDA_ENV_NAME="lsst-scipipe-${LSST_SPLENV_REF}"

--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -96,36 +96,33 @@ case $(uname -s) in
     ;;
 esac
 
-(
-  cd "$LSSTSW"
+cd "$LSSTSW"
 
-  OPTS=()
+OPTS=()
 
-  # shellcheck disable=SC2154
-  if [[ $LSST_DEPLOY_MODE == bleed ]]; then
-    OPTS+=('-b')
-  fi
+# shellcheck disable=SC2154
+if [[ $LSST_DEPLOY_MODE == bleed ]]; then
+  OPTS+=('-b')
+fi
 
-  if [[ -z "$RUBINENV_ORG_FORK" ]]; then
-    # The LSST_SPLENV_REF can refer to a rubin-env version
-    #  or to an old scipipe_conda_env SHA1
-    if [[ $LSST_SPLENV_REF =~ [0-9]+\.[0-9]+\.[0-9A-Za-z-]+ ]]; then
-      ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
-    else
-      # this may be required in case we want to do a patch on a major release
-      #  pre instroduction of rubin-env
-      ./bin/deploy -r "$LSST_SPLENV_REF" "${OPTS[@]}"
-    fi
-    LSST_CONDA_ENV_NAME="lsst-scipipe-${LSST_SPLENV_REF}"
-  else
-    # build and deploy a rubinenv environment from fork/branch
+if [[ -z "$RUBINENV_ORG_FORK" ]]; then
+  # The LSST_SPLENV_REF can refer to a rubin-env version
+  #  or to an old scipipe_conda_env SHA1
+  if [[ $LSST_SPLENV_REF =~ [0-9]+\.[0-9]+\.[0-9A-Za-z-]+ ]]; then
     ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
-    ./bin/set_prereleased_env "$RUBINENV_ORG_FORK" "$RUBINENV_BRANCH"
-    LSST_CONDA_ENV_NAME=$(cat rubinenv-feedstock/env.name)
+  else
+    # this may be required in case we want to do a patch on a major release
+    #  pre instroduction of rubin-env
+    ./bin/deploy -r "$LSST_SPLENV_REF" "${OPTS[@]}"
   fi
-)
-# environment name is used in envconfig (previously setup.sh) called from lsstswBuild.sh
-export LSST_CONDA_ENV_NAME
+  export LSST_CONDA_ENV_NAME="lsst-scipipe-${LSST_SPLENV_REF}"
+else
+  # build and deploy a rubinenv environment from fork/branch
+  ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
+  ./bin/set_prereleased_env "$RUBINENV_ORG_FORK" "$RUBINENV_BRANCH"
+  export LSST_CONDA_ENV_NAME="$(cat rubinenv-feedstock/env.name)"
+fi
+
 "${SCRIPT_DIR}/lsstswBuild.sh" "${ARGS[@]}"
 
 # vim: tabstop=2 shiftwidth=2 expandtab

--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -106,10 +106,17 @@ esac
     OPTS+=('-b')
   fi
 
-  # updated from -r to -v whit the introduction of rubin-env
-  ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
+  # The LSST_SPLENV_REF can refer to a rubin-env version
+  #  or to an old scipipe_conda_env SHA1
+  if [[ $LSST_SPLENV_REF =~ [0-9]+\.[0-9]+\.[0-9A-Za-z-]+ ]]; then
+    ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
+  else
+    # this may be required in case we want to do a patch on a major release
+    #  pre instroduction of rubin-env
+    ./bin/deploy -r "$LSST_SPLENV_REF" "${OPTS[@]}"
+  fi
 )
-# environment name is used in setup.sh called from lsstswBuild.sh
+# environment name is used in envconfig (previously setup.sh) called from lsstswBuild.sh
 export LSST_CONDA_ENV_NAME="lsst-scipipe-${LSST_SPLENV_REF}"
 "${SCRIPT_DIR}/lsstswBuild.sh" "${ARGS[@]}"
 

--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -115,13 +115,15 @@ if [[ -z "$RUBINENV_ORG_FORK" ]]; then
     #  pre instroduction of rubin-env
     ./bin/deploy -r "$LSST_SPLENV_REF" "${OPTS[@]}"
   fi
-  export LSST_CONDA_ENV_NAME="lsst-scipipe-${LSST_SPLENV_REF}"
+  LSST_CONDA_ENV_NAME="lsst-scipipe-${LSST_SPLENV_REF}"
 else
   # build and deploy a rubinenv environment from fork/branch
   ./bin/deploy -v "$LSST_SPLENV_REF" "${OPTS[@]}"
   ./bin/set_prereleased_env "$RUBINENV_ORG_FORK" "$RUBINENV_BRANCH"
-  export LSST_CONDA_ENV_NAME="$(cat rubinenv-feedstock/env.name)"
+  LSST_CONDA_ENV_NAME="$(cat rubinenv-feedstock/env.name)"
 fi
+
+export LSST_CONDA_ENV_NAME
 
 "${SCRIPT_DIR}/lsstswBuild.sh" "${ARGS[@]}"
 

--- a/lsstswBuild.sh
+++ b/lsstswBuild.sh
@@ -5,6 +5,8 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # shellcheck source=./settings.cfg.sh
 source "${SCRIPT_DIR}/settings.cfg.sh"
+# Passing dummy parameter (0) to envconfig, othervise
+#  current parameters and options are passed to the sourced script
 # shellcheck source=/dev/null
 source "${LSSTSW}/bin/envconfig" 0
 

--- a/lsstswBuild.sh
+++ b/lsstswBuild.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # shellcheck source=./settings.cfg.sh
 source "${SCRIPT_DIR}/settings.cfg.sh"
 # shellcheck source=/dev/null
-source "${LSSTSW}/bin/setup.sh"
+source "${LSSTSW}/bin/envconfig"
 
 set -eo pipefail
 

--- a/lsstswBuild.sh
+++ b/lsstswBuild.sh
@@ -6,7 +6,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # shellcheck source=./settings.cfg.sh
 source "${SCRIPT_DIR}/settings.cfg.sh"
 # shellcheck source=/dev/null
-source "${LSSTSW}/bin/envconfig"
+source "${LSSTSW}/bin/envconfig" 0
+
 
 set -eo pipefail
 


### PR DESCRIPTION
In addition to implementing rubin-env, the following changes have been made:

- keep backward compatibility with scipipe-conda-env
- It has been added the possibility to build using also a rubin-env fork, when an environment is in consolidation.
- changed from bin/setup.sh to bin/envconfig
- removed the call to bin/deploy (it shall already have been done)