### PR TITLE
Build a local copy of jointcal master

### DIFF
--- a/run_verify_drp_metrics.sh
+++ b/run_verify_drp_metrics.sh
@@ -93,7 +93,16 @@ else
 fi
 
 setup -k -r "$LSST_VERIFY_DRP_METRICS_DATASET_DIR"
+
 set -o xtrace
+
+############ This is a hack to get around the fact that jointcal uses configs that are stripped in the container
+git clone https://github.com/lsst/jointcal
+cd jointcal
+setup -k -r .
+scons
+cd ..
+########### 
 
 case "$LSST_VERIFY_DRP_METRICS_DATASET" in
   validation_data_cfht)

--- a/run_verify_drp_metrics.sh
+++ b/run_verify_drp_metrics.sh
@@ -97,11 +97,13 @@ setup -k -r "$LSST_VERIFY_DRP_METRICS_DATASET_DIR"
 set -o xtrace
 
 ############ This is a hack to get around the fact that jointcal uses configs that are stripped in the container
+
 git clone https://github.com/lsst/jointcal
+setup -k -r jointcal
+(
 cd jointcal
-setup -k -r .
 scons
-cd ..
+)
 ########### 
 
 case "$LSST_VERIFY_DRP_METRICS_DATASET" in


### PR DESCRIPTION
This is a temporary work around since jointcal accesses files in the test directory which is stripped out when containers are built.  When DM-30899 merges.