### PR TITLE
DM-32648: Replace master doxy type with main.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ci-scripts
 ===
 
-[![Build Status](https://travis-ci.org/lsst-sqre/ci-scripts.png)](https://travis-ci.org/lsst-sqre/ci-scripts)
-
 This repo began as an import of the state of lsst-dev:/home/buildbot/RHEL6/scripts
 as of 2015-03-17.  These scripts were invoked by the buildbot worker that
 was running on lsst-dev; they are now invoked by Jenkins agents.

--- a/create_xlinkdocs.sh
+++ b/create_xlinkdocs.sh
@@ -32,7 +32,7 @@ usage() {
 		 type: either <git-branch>,  \"stable\", or \"beta\"
 		 path: actual path to the publicly accessible DM doxygen documentation
 
-		 Example: $0 --type master --path /home/foo/public_html/doxygen
+		 Example: $0 --type main --path /home/foo/public_html/doxygen
 		 Example: $0 --type Winter2012 ---path /home/foo/public_html/doxygen
 		 Example: $0 --type stable --path /home/foo/public_html/doxygen
 
@@ -61,14 +61,14 @@ fi
 DATE="$(date +%Y)_$(date +%m)_$(date +%d)_$(date +%H.%M.%S)"
 
 # Normative doxy_type needs to be one of {normative(<branch>), beta, stable}
-#   but doxy_type for master branch will now change to the tag name used
-#   for a master build
+#   but doxy_type for main branch will now change to the tag name used
+#   for a main build
 NORMATIVE_DOXY_TYPE=$(echo "$DOXY_TYPE" | tr  "/" "_")
-if [[ $DOXY_TYPE == master ]]; then
+if [[ $DOXY_TYPE == main ]]; then
   eval "$(grep -E '^BUILD=' "$LSSTSW_BUILD_DIR"/manifest.txt)"
   echo "BUILD: $BUILD"
   if [[ -z $BUILD ]]; then
-    fail "*** Failed: to determine most recent master build number."
+    fail "*** Failed: to determine most recent main build number."
   else
     DOXY_TYPE=$BUILD
   fi
@@ -107,7 +107,7 @@ if ! ( set -e
   # Ensure fresh extraction
   rm -rf "$DOC_REPO_DIR"
 
-  # SCM clone lsstDoxygen ** from master **
+  # SCM clone lsstDoxygen ** from default branch **
   git clone "$DOC_REPO_URL" "$DOC_REPO_DIR"
 ); then
   fail "*** Failed to clone '$DOC_REPO_URL'."

--- a/lsstswBuild.sh
+++ b/lsstswBuild.sh
@@ -195,7 +195,7 @@ if [[ $BUILD_DOCS == true ]]; then
 
   print_info "Start Documentation build at: $(date)"
   if ! run "${SCRIPT_DIR}/create_xlinkdocs.sh" \
-    --type "master" \
+    --type "main" \
     --path "$DOC_PUSH_PATH"; then
     fail "*** FAILURE: Doxygen document was not installed."
   fi


### PR DESCRIPTION
Not yet changing things like the Jenkinsfile, so this could actually be merged ahead of time (although it would cause links in pipelines.lsst.io to be outdated).