### PR TITLE
DM-40447: Use separate dir for official release doxygen.

### DIFF
--- a/create_xlinkdocs.sh
+++ b/create_xlinkdocs.sh
@@ -64,14 +64,12 @@ DATE="$(date +%Y)_$(date +%m)_$(date +%d)_$(date +%H.%M.%S)"
 #   but doxy_type for main branch will now change to the tag name used
 #   for a main build
 NORMATIVE_DOXY_TYPE=$(echo "$DOXY_TYPE" | tr  "/" "_")
-if [[ $DOXY_TYPE == main ]]; then
-  eval "$(grep -E '^BUILD=' "$LSSTSW_BUILD_DIR"/manifest.txt)"
-  echo "BUILD: $BUILD"
-  if [[ -z $BUILD ]]; then
-    fail "*** Failed: to determine most recent main build number."
-  else
-    DOXY_TYPE=$BUILD
-  fi
+eval "$(grep -E '^BUILD=' "$LSSTSW_BUILD_DIR"/manifest.txt)"
+echo "BUILD: $BUILD"
+if [[ -z $BUILD ]]; then
+  fail "*** Failed: to determine most recent main build number."
+else
+  DOXY_TYPE=$BUILD
 fi
 
 SYM_LINK_NAME="x_${NORMATIVE_DOXY_TYPE}DoxyDoc"

--- a/lsstswBuild.sh
+++ b/lsstswBuild.sh
@@ -204,8 +204,13 @@ if [[ $BUILD_DOCS == true ]]; then
   start_section "doc build"
 
   print_info "Start Documentation build at: $(date)"
+  if [[ "${REF_LIST[0]}" == "v*" ]]; then
+    DOC_TYPE="${REF_LIST[0]}"
+  else
+    DOC_TYPE="main"
+  fi
   if ! run "${SCRIPT_DIR}/create_xlinkdocs.sh" \
-    --type "main" \
+    --type "$DOC_TYPE" \
     --path "$DOC_PUSH_PATH"; then
     fail "*** FAILURE: Doxygen document was not installed."
   fi


### PR DESCRIPTION
In particular, do _not_ link it into x_mainDoxyDoc, which is now reserved for "current" nightly/weekly releases.